### PR TITLE
Changes so that tao works with BOINC 7.23.0 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 db.inc
+
+# Ignore build directory
+build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "php/bootstrap"]
 	path = php/bootstrap
-	url = git://github.com/twitter/bootstrap.git
+	url = https://github.com/twitter/bootstrap.git

--- a/asynchronous_algorithms/CMakeLists.txt
+++ b/asynchronous_algorithms/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(${Boost_INCLUDE_DIR})
 
-add_library(asynchronous_algorithms evolutionary_algorithm particle_swarm differential_evolution individual asynchronous_newton_method asynchronous_genetic_search ant_colony_optimization neat ant_colony_optimization_new)
+add_library(asynchronous_algorithms evolutionary_algorithm.cxx particle_swarm.cxx differential_evolution.cxx individual.cxx asynchronous_newton_method.cxx asynchronous_genetic_search.cxx ant_colony_optimization.cxx neat.cxx ant_colony_optimization_new.cxx)
 #add_library(asynchronous_algorithms evolutionary_algorithm particle_swarm differential_evolution individual asynchronous_newton_method asynchronous_genetic_search)
 target_link_libraries(asynchronous_algorithms ${UNDVC_COMMON_LIBRARY} tao_util)
 
@@ -8,7 +8,7 @@ if (MYSQL_FOUND)
     include_directories(${MYSQL_INCLUDE_DIR})
     include_directories(${MYSQL_INCLUDE_DIR}/mysql)
 
-    add_library(db_asynchronous_algorithms particle_swarm_db differential_evolution_db asynchronous_newton_method_db)
+    add_library(db_asynchronous_algorithms particle_swarm_db.cxx differential_evolution_db.cxx asynchronous_newton_method_db.cxx)
     target_link_libraries(db_asynchronous_algorithms ${UNDVC_COMMON_LIBRARY} tao_util ${MYSQL_LIBRARIES})
 else (MYSQL_FOUND)
     message(STATUS "MYSQL not found, not compiling database enabled evolutionary algorithms")

--- a/boinc/CMakeLists.txt
+++ b/boinc/CMakeLists.txt
@@ -13,10 +13,10 @@ include_directories(
 	${MYSQL_INCLUDE_DIR}
 )
 
-add_executable(tao_validator ${BOINC_INCLUDE_DIR}/sched/validator ${BOINC_INCLUDE_DIR}/sched/validate_util ${BOINC_INCLUDE_DIR}/lib/md5_file tao_validation_policy)
+add_executable(tao_validator ${BOINC_INCLUDE_DIR}/sched/validator.cpp ${BOINC_INCLUDE_DIR}/sched/validate_util.cpp ${BOINC_INCLUDE_DIR}/sched/script_validator.cpp ${BOINC_INCLUDE_DIR}/lib/md5_file.cpp tao_validation_policy.cxx)
 target_link_libraries(tao_validator db_asynchronous_algorithms asynchronous_algorithms ${BOINC_SERVER_LIBRARIES} ${MYSQL_LIBRARIES})
 
-add_executable(tao_assimilator ${BOINC_INCLUDE_DIR}/sched/assimilator tao_assimilation_policy)
+add_executable(tao_assimilator ${BOINC_INCLUDE_DIR}/sched/assimilator.cpp tao_assimilation_policy.cxx)
 target_link_libraries(tao_assimilator ${BOINC_SERVER_LIBRARIES} ${MYSQL_LIBRARIES})
 
 #find_package(CURL REQUIRED)
@@ -28,18 +28,18 @@ include_directories(
 
 add_definitions(-D__MW_SEPARATION__)
 
-add_executable(tao_work_generator tao_work_generator workunit_information)
+add_executable(tao_work_generator tao_work_generator.cxx workunit_information.cxx)
 #target_link_libraries(tao_work_generator asynchronous_algorithms db_asynchronous_algorithms ${UNDVC_COMMON_LIBRARY} ${BOINC_SERVER_LIBRARIES} ${MYSQL_LIBRARIES} ${OPENSSL_LIBRARIES} ${CURL_LIBRARIES})
 target_link_libraries(tao_work_generator db_asynchronous_algorithms asynchronous_algorithms ${UNDVC_COMMON_LIBRARY} ${BOINC_SERVER_LIBRARIES} ${MYSQL_LIBRARIES} ${OPENSSL_LIBRARIES})
 
 
-add_executable(tao_stop_search tao_stop_search messages)
+add_executable(tao_stop_search tao_stop_search.cxx messages.cxx)
 #target_link_libraries(tao_work_generator asynchronous_algorithms db_asynchronous_algorithms ${UNDVC_COMMON_LIBRARY} ${BOINC_SERVER_LIBRARIES} ${MYSQL_LIBRARIES} ${OPENSSL_LIBRARIES} ${CURL_LIBRARIES})
 target_link_libraries(tao_stop_search db_asynchronous_algorithms asynchronous_algorithms ${UNDVC_COMMON_LIBRARY} ${BOINC_SERVER_LIBRARIES} ${MYSQL_LIBRARIES} ${OPENSSL_LIBRARIES})
 
-add_executable(tao_search_status tao_search_status messages)
+add_executable(tao_search_status tao_search_status.cxx messages.cxx)
 #target_link_libraries(tao_work_generator asynchronous_algorithms db_asynchronous_algorithms ${UNDVC_COMMON_LIBRARY} ${BOINC_SERVER_LIBRARIES} ${MYSQL_LIBRARIES} ${OPENSSL_LIBRARIES} ${CURL_LIBRARIES})
 target_link_libraries(tao_search_status db_asynchronous_algorithms asynchronous_algorithms ${UNDVC_COMMON_LIBRARY} ${BOINC_SERVER_LIBRARIES} ${MYSQL_LIBRARIES} ${OPENSSL_LIBRARIES})
 
-add_library(workunit_information workunit_information)
+add_library(workunit_information workunit_information.cxx)
 target_link_libraries(workunit_information ${UNDVC_COMMON_LIBRARY} ${BOINC_SERVER_LIBRARIES} ${MYSQL_LIBRARIES} ${OPENSSL_LIBRARIES})

--- a/boinc/tao_validation_policy.cxx
+++ b/boinc/tao_validation_policy.cxx
@@ -59,7 +59,7 @@ variate_generator< mt11213b, uniform_real<> > random_number_generator(mt11213b( 
 /* New BOINC mandated usage and init functions.
  * These can be updated in the future, but we will just say they succeed for now.
  */
-void validate_handler_usage(){
+/*void validate_handler_usage(){
     return;
 }
 
@@ -67,7 +67,7 @@ void validate_handler_usage(){
 int validate_handler_init(int argc, char** argv) {
     return 0;
 }
-
+*/
 /*
  * Given a set of results, check for a canonical result,
  * i.e. a set of at least min_quorum/2+1 results for which

--- a/boinc/tao_work_generator.cxx
+++ b/boinc/tao_work_generator.cxx
@@ -34,6 +34,7 @@
 #include "backend_lib.h"
 #include "parse.h"
 #include "util.h"
+#include "filesys.h"
 #include "svn_version.h"
 
 #include "sched_config.h"

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,13 +2,13 @@ include_directories (${PROJECT_SOURCE_DIR}/evolutionary_algorithms)
 include_directories (${PROJECT_SOURCE_DIR}/deterministic_algorithms)
 include_directories (${Boost_INCLUDE_DIR})
 
-add_executable(StandardBenchmarks standard_benchmarks)
+add_executable(StandardBenchmarks standard_benchmarks.cxx)
 target_link_libraries(StandardBenchmarks asynchronous_algorithms ${UNDVC_COMMON_LIBRARY} tao_util ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 
 if (MYSQL_FOUND)
     include_directories (${MYSQL_INCLUDE_DIR})
-    add_executable(StandardBenchmarksDB standard_benchmarks_db)
+    add_executable(StandardBenchmarksDB standard_benchmarks_db.cxx)
     target_link_libraries(StandardBenchmarksDB ${UNDVC_COMMON_LIBRARY} asynchronous_algorithms db_asynchronous_algorithms ${MYSQL_LIBRARIES})
 else (MYSQL_FOUND)
     message(STATUS "MYSQL not found, not compiling database enabled examples")

--- a/mpi/CMakeLists.txt
+++ b/mpi/CMakeLists.txt
@@ -13,7 +13,7 @@ if (MPI_FOUND)
     #    cuda_add_library(mpi_algorithms mpi_genetic_algorithm mpi_particle_swarm mpi_differential_evolution master_worker assign_device)
     #    target_link_libraries(mpi_algorithms asynchronous_algorithms ${UNDVC_COMMON_LIBRARY} tao_util ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${MPI_LIBRARIES} ${CUDA_LIBRARIES})
     #else (CUDA_FOUND)
-        add_library(mpi_algorithms mpi_genetic_algorithm mpi_particle_swarm mpi_differential_evolution master_worker mpi_ant_colony_optimization mpi_ant_colony_optimization_new)
+        add_library(mpi_algorithms mpi_genetic_algorithm.cxx mpi_particle_swarm mpi_differential_evolution.cxx master_worker.cxx mpi_ant_colony_optimization.cxx mpi_ant_colony_optimization_new.cxx)
         target_link_libraries(mpi_algorithms asynchronous_algorithms ${UNDVC_COMMON_LIBRARY} tao_util ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${MPI_LIBRARIES})
     #endif (CUDA_FOUND)
 

--- a/neural_networks/CMakeLists.txt
+++ b/neural_networks/CMakeLists.txt
@@ -8,10 +8,10 @@ IF (OPENCL_INCLUDE_DIRS)
 
     include_directories(${OPENCL_INCLUDE_DIRS})
 
-    add_library(neural_networks neural_network time_series_neural_network edge convolutional_neural_network opencl_utils edge_new ${OpenCV_LIBRARIES} ${OPENCL_LIBRARIES})
+    add_library(neural_networks neural_network.cxx time_series_neural_network.cxx edge.cxx convolutional_neural_network.cxx opencl_utils.cxx edge_new.cxx ${OpenCV_LIBRARIES} ${OPENCL_LIBRARIES})
 ELSE (OPENCL_INCLUDE_DIRS)
 
-    add_library(neural_networks neural_network time_series_neural_network edge convolutional_neural_network edge_new ${OpenCV_LIBRARIES})
+    add_library(neural_networks neural_network.cxx time_series_neural_network.cxx edge.cxx convolutional_neural_network.cxx edge_new.cxx ${OpenCV_LIBRARIES})
 
 ENDIF(OPENCL_INCLUDE_DIRS)
 

--- a/synchronous_algorithms/CMakeLists.txt
+++ b/synchronous_algorithms/CMakeLists.txt
@@ -1,4 +1,4 @@
 include_directories(${Boost_INCLUDE_DIR})
 
-add_library(synchronous_algorithms parameter_sweep synchronous_gradient_descent synchronous_newton_method gradient line_search)
+add_library(synchronous_algorithms parameter_sweep.cxx synchronous_gradient_descent.cxx synchronous_newton_method.cxx gradient.cxx line_search.cxx)
 target_link_libraries(synchronous_algorithms ${UNDVC_COMMON_LIBRARY} tao_util ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -2,13 +2,13 @@ include_directories(${Boost_INCLUDE_DIR})
 
 message(STATUS "boost include dir: ${Boost_INCLUDE_DIR}")
 
-add_library(tao_util recombination ../asynchronous_algorithms/individual statistics matrix hessian newton_step tao_random)
+add_library(tao_util recombination.cxx ../asynchronous_algorithms/individual.cxx statistics.cxx matrix.cxx hessian.cxx newton_step.cxx tao_random.cxx)
 target_link_libraries(tao_util ${UNDVC_COMMON_LIBRARY} ${BOOST_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
-add_executable(matrix_mul_test matrix)
+add_executable(matrix_mul_test matrix.cxx)
 target_link_libraries(matrix_mul_test ${UNDVC_COMMON_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 set_target_properties(matrix_mul_test PROPERTIES COMPILE_FLAGS -DMATRIX_MUL_TEST)
 
-add_executable(matrix_inverse_test matrix)
+add_executable(matrix_inverse_test matrix.cxx)
 target_link_libraries(matrix_inverse_test ${UNDVC_COMMON_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 set_target_properties(matrix_inverse_test PROPERTIES COMPILE_FLAGS -DMATRIX_INVERSE_TEST)


### PR DESCRIPTION
- added build directory in .gitignore
- changed .gitmodules to https 
- changed all CMakeLists.txt to include file type to get rid of warnings for add_library and add_excecutable 
- added #include for filesys.h in tao_work_generator for read_file_malloc in filesys.cpp definition previously defined in util.cpp 
- change to CMakeLists.txt in boinc folder to include script_validator.cpp for in add_executable(tao_validator ....) to fix undefined reference to init_result and cleanup_result error  
- Commenting out duplicate definitions of  validate_handler_usage and validate_handler_init in tao_validation_policy.cxx since defined in script_validator.cpp
